### PR TITLE
[모질라 허브 문서 / 스포크(Spoke)로 장면(Scene) 빌드하기] 이미지 링크 주소를 정정합니다

### DIFF
--- a/docs/intro-spoke.md
+++ b/docs/intro-spoke.md
@@ -25,7 +25,7 @@ sidebar_label: 스포크(Spoke)로 장면(Scene) 빌드하기
 콘텐츠를 허브에 즉시 게시하여 새로운 공간에서 사람들을 초대합니다. 단 몇 번의 클릭만으로 브라우저에서 &mdash를 경험하고 공유할 수 있습니다.
 
 
-![Speak의 스크린샷](img/introspoke-screenshot-min.jpeg)
+![Speak의 스크린샷](img/intro-spoke-screenshot-min.jpeg)
 
 
 ## 시작하기


### PR DESCRIPTION
안녕하세요.

모질라 허브 문서 by BELIVVR Developers 문서를 읽던 중에

[스포크(Spoke)로 장면(Scene) 빌드하기](https://developers.belivvr.com/docs/mozilla-hubs/intro-spoke.html)에 **Speak의 스크린샷** 이미지 링크가 깨진 것을 발견하여 올바른 링크 주소로 변경하였습니다.

해당 내용 확인 요청드리겠습니다.

감사합니다 😄 
